### PR TITLE
Make templates easier to debug by not burying errors

### DIFF
--- a/lib/slim_assets/slim_sprockets_engine.rb
+++ b/lib/slim_assets/slim_sprockets_engine.rb
@@ -25,12 +25,7 @@ module SlimAssets
     end
 
     def evaluate(scope, locals, &block)
-      begin
-        "" + render_slim(view_context(scope), locals)
-      rescue Exception => e
-        Rails.logger.error "ERROR: compiling #{file} RAISED #{e}"
-        Rails.logger.error "Backtrace: #{e.backtrace.join("\n")}"
-      end
+      "" + render_slim(view_context(scope), locals)
     end
 
     protected


### PR DESCRIPTION
I've found it very difficult to debug issues within .hbs.slim (or whatever) templates because slim_assets burys the errors.

For instance, if I try to access a non existant helper previously I would get the following unhelpful error:

> Error: You must pass a string or Handlebars AST to Handlebars.compile. You passed true
>   (in /Users/mattvague/Work/MetaLab/everchron/app/assets/templates/documents/form.hbs.slim)

But this patch will give you:

> undefined method `nice_date' for...

I feel like there's probably a reason you used `Rails.logger.error` but I'm not sure what it is
